### PR TITLE
Fixed shell detection + Unicode error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ A [Powerline](https://github.com/Lokaltog/vim-powerline) like prompt for Bash:
         }
 
         export PROMPT_COMMAND="_update_ps1"
+
+* Or add this to your .zshrc:
+
+    setopt prompt_subst
+
+    precmd() {
+        PROMPT=$(~/powerline-bash.py $?)
+    }
+

--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import re
+import string
 
 class Powerline:
     symbols = {
@@ -17,7 +18,11 @@ class Powerline:
             'separator_thin': u'\u2B81'
         }
     }
-    LSQESCRSQ = '\\[\\e%s\\]'
+    o,_ = (subprocess.Popen(r"ps -p `ps -p $PPID -o ppid | tail -1` | awk '{ print $NF }' | tail -1", shell=True, stdout=subprocess.PIPE)).communicate()
+    if string.strip(o) == 'zsh':
+        LSQESCRSQ = '\x1B%s'
+    else:
+        LSQESCRSQ = '\\[\\e%s\\]'
     reset = LSQESCRSQ % '[0m'
 
     def __init__(self, mode='compatible'):


### PR DESCRIPTION
w/r/t this: https://github.com/Fusion/powerline-bash/commit/cfc579464495afeafba5b5911b6e7d73623fcfc6#commitcomment-1894173 as you can see in my last comment, using $SHELL works well :)

I am submitting this changelist instead because I found that directly including the ellipsis character in the source code causes Python 2.7 to choke.