### PR TITLE
Explicit Python 2.

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import stat
 

--- a/themes/colortest.py
+++ b/themes/colortest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 
 ESCAPE = chr(27)


### PR DESCRIPTION
Arch Linux defaults to Python 3, so, this breaks because you're using Python 2.