### PR TITLE
added support for time segment

### DIFF
--- a/config.py.dist
+++ b/config.py.dist
@@ -10,6 +10,9 @@ SEGMENTS = [
 # Show current virtual environment (see http://www.virtualenv.org/)
     'virtual_env',
 
+# Show current time
+    'time',
+
 # Show the current user's username as in ordinary prompts
     'username',
 

--- a/segments/time.py
+++ b/segments/time.py
@@ -1,0 +1,12 @@
+def add_time_segment():
+    if powerline.args.shell == 'bash':
+        time = ' \\t '
+    elif powerline.args.shell == 'zsh':
+        time = ' %* '
+    else:
+        import time
+        time = ' %s ' % time.strftime('%H:%M:%S')
+
+    powerline.append(time, Color.HOSTNAME_FG, Color.HOSTNAME_BG)
+
+add_time_segment()


### PR DESCRIPTION
I usually like to have some evidence of the current time on the console. I added this segment only with the time, because the date and time would have taken a lot of space, but it is extensible to also have it. I tested this on a bash environment, and don't know if this will work on zsh or any other shell.