### PR TITLE
[ADD] argument --cwd-max-dir-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ There are a few optional arguments which can be seen by running `powerline-shell
   --cwd-only            Only show the current directory
   --cwd-max-depth CWD_MAX_DEPTH
                         Maximum number of directories to show in path
+  --cwd-max-dir-size CWD_MAX_DIR_SIZE
+                        Maximum number of letters displayed for each directory
+                        in the path
   --colorize-hostname   Colorize the hostname based on a hash of itself.
   --mode {patched,compatible,flat}
                         The characters used to make separators between

--- a/powerline_shell_base.py
+++ b/powerline_shell_base.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
             help='Only show the current directory')
     arg_parser.add_argument('--cwd-max-depth', action='store', type=int,
             default=5, help='Maximum number of directories to show in path')
+    arg_parser.add_argument('--cwd-max-dir-size', action='store', type=int,
+            help='Maximum number of letters displayed for each directory in the path')
     arg_parser.add_argument('--colorize-hostname', action='store_true',
             help='Colorize the hostname based on a hash of itself.')
     arg_parser.add_argument('--mode', action='store', default='patched',

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -23,6 +23,8 @@ def add_cwd_segment():
 
     if not powerline.args.cwd_only:
         for n in names[:-1]:
+            if powerline.args.cwd_max_dir_size:
+                n = n[:powerline.args.cwd_max_dir_size]
             if n == '~' and Color.HOME_SPECIAL_DISPLAY:
                 powerline.append(' %s ' % n, Color.HOME_FG, Color.HOME_BG)
             else:


### PR DESCRIPTION
This allows to restrict the size of each displayed folder in the path.

This is usefull to keep a minimum space usage for longer path. eg: for /usr/lib/python2.7/site-packages with value of 2, the displayed path would be '/us/li/py/si'

fix #112