### PR TITLE
Feature/gitsegment

### DIFF
--- a/segments/git.py
+++ b/segments/git.py
@@ -23,6 +23,15 @@ def get_git_status(pdata):
 
 
 def add_git_segment():
+    symbols = {
+        'detached': u'\u2693',
+        'ahead': u'\u2B06',
+        'behind': u'\u2B07',
+        'staged': u'\u2714',
+        'notstaged': u'\u270E',
+        'conflicted': u'\u273C'
+    }
+
     p = subprocess.Popen(['git', 'status', '--porcelain', '-b'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     pdata = p.communicate()
     if p.returncode != 0:
@@ -36,7 +45,7 @@ def add_git_segment():
         p = subprocess.Popen(['git', 'describe', '--tags', '--always'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         detached_ref = p.communicate()[0].rstrip('\n')
         if p.returncode == 0:
-            branch = '⚓ {}'.format(detached_ref).decode('utf-8')
+            branch = '%c %s' % (symbols['detached'], detached_ref.decode('utf-8'))
         else:
             branch = 'Big Bang'
 
@@ -50,17 +59,17 @@ def add_git_segment():
 
     if branchinfo:
         if branchinfo['ahead']:
-            powerline.append("{}⬆".format(branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('')).decode('utf-8'), Color.GIT_AHEAD_FG, Color.GIT_AHEAD_BG)
+            powerline.append('%s%c' % (branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('').decode('utf-8'), symbols['ahead']), Color.GIT_AHEAD_FG, Color.GIT_AHEAD_BG)
         if branchinfo['behind']:
-            powerline.append("{}⬇".format(branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('')).decode('utf-8'), Color.GIT_BEHIND_FG, Color.GIT_BEHIND_BG)
+            powerline.append('%s%c' % (branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('').decode('utf-8'), symbols['behind']), Color.GIT_BEHIND_FG, Color.GIT_BEHIND_BG)
     if stats['staged']:
-        powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), Color.GIT_STAGED_FG, Color.GIT_STAGED_BG)
+        powerline.append('%s%c' % (stats['staged'] if stats['staged'] > 1 else str('').decode('utf-8'), symbols['staged']), Color.GIT_STAGED_FG, Color.GIT_STAGED_BG)
     if stats['notstaged']:
-        powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
+        powerline.append('%s%c' % (stats['notstaged'] if stats['notstaged'] > 1 else str('').decode('utf-8'), symbols['notstaged']), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
     if stats['untracked']:
-        powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
+        powerline.append('%s?' % (stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
     if stats['conflicted']:
-        powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
+        powerline.append('%s%c' % (stats['conflicted'] if stats['conflicted'] > 1 else str('').decode('utf-8'), symbols['conflicted']), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
 try:
     add_git_segment()
 except OSError:

--- a/segments/git.py
+++ b/segments/git.py
@@ -1,60 +1,66 @@
 import re
 import subprocess
 
-def get_git_status():
-    has_pending_commits = True
-    has_untracked_files = False
-    origin_position = ""
-    output = subprocess.Popen(['git', 'status', '--ignore-submodules'],
-            env={"LANG": "C", "HOME": os.getenv("HOME")}, stdout=subprocess.PIPE).communicate()[0]
-    for line in output.split('\n'):
-        origin_status = re.findall(
-            r"Your branch is (ahead|behind).*?(\d+) comm", line)
-        if origin_status:
-            origin_position = " %d" % int(origin_status[0][1])
-            if origin_status[0][0] == 'behind':
-                origin_position += u'\u21E3'
-            if origin_status[0][0] == 'ahead':
-                origin_position += u'\u21E1'
+def get_git_status(pdata):
+    status = pdata[0].splitlines()
 
-        if line.find('nothing to commit') >= 0:
-            has_pending_commits = False
-        if line.find('Untracked files') >= 0:
-            has_untracked_files = True
-    return has_pending_commits, has_untracked_files, origin_position
+    branchinfo = re.search('^## (?P<local>\S+)(\.{3}(?P<remote>\S+)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?\])?)?$', status[0])
+
+    stats = {'untracked': 0, 'notstaged': 0, 'staged': 0, 'conflicted': 0}
+    for statusline in status[1:]:
+        code = statusline[:2]
+        if code == '??':
+            stats['untracked'] += 1
+        elif code in ('DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU'):
+            stats['conflicted'] += 1
+        else:
+            if code[1] != ' ':
+                stats['notstaged'] += 1
+            if code[0] != ' ':
+                stats['staged'] += 1
+    dirty = (True if sum(stats.values()) > 0 else False)
+    return dirty, stats, branchinfo.groupdict() if branchinfo else None
 
 
 def add_git_segment():
-    # See http://git-blame.blogspot.com/2013/06/checking-current-branch-programatically.html
-    p = subprocess.Popen(['git', 'symbolic-ref', '-q', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-
-    if 'Not a git repo' in err:
+    p = subprocess.Popen(['git', 'status', '--porcelain', '-b'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    pdata = p.communicate()
+    if p.returncode != 0:
         return
 
-    if out:
-        branch = out[len('refs/heads/'):].rstrip()
+    dirty, stats, branchinfo = get_git_status(pdata)
+
+    if branchinfo:
+        branch = branchinfo['local']
     else:
-        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        commit_hash_out, commit_hash_err = (x.rstrip('\n') for x in p.communicate())
-
-        p = subprocess.Popen(['git', 'describe', '--exact-match', '--tags', commit_hash_out], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        tag_hash_out, tag_hash_err = (x.rstrip('\n') for x in p.communicate())
-        branch = '➤ {}'.format(tag_hash_out if p.returncode == 0 else commit_hash_out).decode('utf-8')
-
-    has_pending_commits, has_untracked_files, origin_position = get_git_status()
-    branch += origin_position
-    if has_untracked_files:
-        branch += ' +'
+        p = subprocess.Popen(['git', 'describe', '--tags', '--always'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        detached_ref = p.communicate()[0].rstrip('\n')
+        if p.returncode == 0:
+            branch = '⚓ {}'.format(detached_ref).decode('utf-8')
+        else:
+            branch = 'Big Bang'
 
     bg = Color.REPO_CLEAN_BG
     fg = Color.REPO_CLEAN_FG
-    if has_pending_commits:
+    if dirty:
         bg = Color.REPO_DIRTY_BG
         fg = Color.REPO_DIRTY_FG
 
     powerline.append(' %s ' % branch, fg, bg)
 
+    if branchinfo:
+        if branchinfo['ahead']:
+            powerline.append("{}⬆".format(branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('')).decode('utf-8'), 250, 240)
+        if branchinfo['behind']:
+            powerline.append("{}⬇".format(branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('')).decode('utf-8'), 250, 240)
+        if stats['staged']:
+            powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), 15, 22)
+        if stats['notstaged']:
+            powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), 15, 130)
+        if stats['untracked']:
+            powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), 15, 52)
+        if stats['conflicted']:
+            powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), 15, 9)
 try:
     add_git_segment()
 except OSError:

--- a/segments/git.py
+++ b/segments/git.py
@@ -50,17 +50,17 @@ def add_git_segment():
 
     if branchinfo:
         if branchinfo['ahead']:
-            powerline.append("{}⬆".format(branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('')).decode('utf-8'), 250, 240)
+            powerline.append("{}⬆".format(branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('')).decode('utf-8'), Color.GIT_AHEAD_FG, Color.GIT_AHEAD_BG)
         if branchinfo['behind']:
-            powerline.append("{}⬇".format(branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('')).decode('utf-8'), 250, 240)
+            powerline.append("{}⬇".format(branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('')).decode('utf-8'), Color.GIT_BEHIND_FG, Color.GIT_BEHIND_BG)
         if stats['staged']:
-            powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), 15, 22)
+            powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), Color.GIT_STAGED_FG, Color.GIT_STAGED_BG)
         if stats['notstaged']:
-            powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), 15, 130)
+            powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
         if stats['untracked']:
-            powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), 15, 52)
+            powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
         if stats['conflicted']:
-            powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), 15, 9)
+            powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
 try:
     add_git_segment()
 except OSError:

--- a/segments/git.py
+++ b/segments/git.py
@@ -35,7 +35,12 @@ def add_git_segment():
     if out:
         branch = out[len('refs/heads/'):].rstrip()
     else:
-        branch = '(Detached)'
+        p = subprocess.Popen(['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        commit_hash_out, commit_hash_err = (x.rstrip('\n') for x in p.communicate())
+
+        p = subprocess.Popen(['git', 'describe', '--exact-match', '--tags', commit_hash_out], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tag_hash_out, tag_hash_err = (x.rstrip('\n') for x in p.communicate())
+        branch = '➤ {}'.format(tag_hash_out if p.returncode == 0 else commit_hash_out).decode('utf-8')
 
     has_pending_commits, has_untracked_files, origin_position = get_git_status()
     branch += origin_position

--- a/segments/git.py
+++ b/segments/git.py
@@ -4,7 +4,7 @@ import subprocess
 def get_git_status(pdata):
     status = pdata[0].splitlines()
 
-    branchinfo = re.search('^## (?P<local>\S+)(\.{3}(?P<remote>\S+)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?\])?)?$', status[0])
+    branchinfo = re.search('^## (?P<local>\S+?)(\.{3}(?P<remote>\S+?)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?\])?)?$', status[0])
 
     stats = {'untracked': 0, 'notstaged': 0, 'staged': 0, 'conflicted': 0}
     for statusline in status[1:]:

--- a/segments/git.py
+++ b/segments/git.py
@@ -53,14 +53,14 @@ def add_git_segment():
             powerline.append("{}⬆".format(branchinfo['ahead'] if int(branchinfo['ahead']) > 1 else str('')).decode('utf-8'), Color.GIT_AHEAD_FG, Color.GIT_AHEAD_BG)
         if branchinfo['behind']:
             powerline.append("{}⬇".format(branchinfo['behind'] if int(branchinfo['behind']) > 1 else str('')).decode('utf-8'), Color.GIT_BEHIND_FG, Color.GIT_BEHIND_BG)
-        if stats['staged']:
-            powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), Color.GIT_STAGED_FG, Color.GIT_STAGED_BG)
-        if stats['notstaged']:
-            powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
-        if stats['untracked']:
-            powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
-        if stats['conflicted']:
-            powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
+    if stats['staged']:
+        powerline.append("{}✔".format(stats['staged'] if stats['staged'] > 1 else str('')).decode('utf-8'), Color.GIT_STAGED_FG, Color.GIT_STAGED_BG)
+    if stats['notstaged']:
+        powerline.append("{}✎".format(stats['notstaged'] if stats['notstaged'] > 1 else str('')).decode('utf-8'), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
+    if stats['untracked']:
+        powerline.append("{}?".format(stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
+    if stats['conflicted']:
+        powerline.append("{}✼".format(stats['conflicted'] if stats['conflicted'] > 1 else str('')).decode('utf-8'), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
 try:
     add_git_segment()
 except OSError:

--- a/segments/git.py
+++ b/segments/git.py
@@ -29,6 +29,7 @@ def add_git_segment():
         'behind': u'\u2B07',
         'staged': u'\u2714',
         'notstaged': u'\u270E',
+        'untracked': u'\u2753',
         'conflicted': u'\u273C'
     }
 
@@ -67,7 +68,7 @@ def add_git_segment():
     if stats['notstaged']:
         powerline.append('%s%c' % (stats['notstaged'] if stats['notstaged'] > 1 else str('').decode('utf-8'), symbols['notstaged']), Color.GIT_NOTSTAGED_FG, Color.GIT_NOTSTAGED_BG)
     if stats['untracked']:
-        powerline.append('%s?' % (stats['untracked'] if stats['untracked'] > 1 else str('')), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
+        powerline.append('%s%c' % (stats['untracked'] if stats['untracked'] > 1 else str('').decode('utf-8'), symbols['untracked']), Color.GIT_UNTRACKED_FG, Color.GIT_UNTRACKED_BG)
     if stats['conflicted']:
         powerline.append('%s%c' % (stats['conflicted'] if stats['conflicted'] > 1 else str('').decode('utf-8'), symbols['conflicted']), Color.GIT_CONFLICTED_FG, Color.GIT_CONFLICTED_BG)
 try:

--- a/themes/default.py
+++ b/themes/default.py
@@ -40,6 +40,19 @@ class DefaultColor:
     SVN_CHANGES_BG = 148
     SVN_CHANGES_FG = 22  # dark green
 
+    GIT_AHEAD_BG = 240
+    GIT_AHEAD_FG = 250
+    GIT_BEHIND_BG = 240
+    GIT_BEHIND_FG = 250
+    GIT_STAGED_BG = 22
+    GIT_STAGED_FG = 15
+    GIT_NOTSTAGED_BG = 130
+    GIT_NOTSTAGED_FG = 15
+    GIT_UNTRACKED_BG = 52
+    GIT_UNTRACKED_FG = 15
+    GIT_CONFLICTED_BG = 9
+    GIT_CONFLICTED_FG = 15
+
     VIRTUAL_ENV_BG = 35  # a mid-tone green
     VIRTUAL_ENV_FG = 00
 


### PR DESCRIPTION
Hello,
This branch enhances the git segment with detailed "git status" overview in the prompt.
- Number of commits behind remote tracking branch
- Number of commits ahead remote tracking branch
- Number of untracked files
- Number of files staged for commit
- Number of files modified but not staged for commit
- Number of conflicted files

- I've improved the detached head mode: currently, when in detached head mode, if there is a tag which describe this commit, the name of the tag is display instead of the sha1. Otherwise, if there is no tag describing HEAD, the sha1 is displayed.

- I've chosen UTF-8 characters for each info.

For the prompt to still be fast, I tried my best to minimize the number of shell commands launched.
In your version, 2 git processes are launched, in my version, I succeed to keep the same number: I only launch 2 git subprocesses, but there is much more info displayed.

I still don't like the default color I chose for "modified but not staged for commit". Do you have a better idea?

This is the longest prompt possible:
![gitsegment_demo](https://f.cloud.github.com/assets/289725/2375934/b823440a-a870-11e3-9742-732f8e2a876f.png)

- The HEAD is detached, and since no tag describes this commit, the sha1 is printed, along with an anchor UTF8 character.
- There are 2 files staged for commit
- The are 3 files modified but not stagged for commit
- There is 1 untracked file
- There is 1 conflicted file (unmerged).