### PR TITLE
Don't escape zsh prompt

### DIFF
--- a/segments/root.py
+++ b/segments/root.py
@@ -1,7 +1,7 @@
 def add_root_indicator_segment():
     root_indicators = {
         'bash': ' \\$ ',
-        'zsh': ' \\$ ',
+        'zsh': ' $ ',
         'bare': ' $ ',
     }
     bg = Color.CMD_PASSED_BG


### PR DESCRIPTION
This would result in a literal \ being printed on the prompt.