### PR TITLE
Fixes to get for python3 virtualenvs working

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import os
 import stat
 
@@ -19,8 +21,15 @@ def load_source(srcfile):
     try:
         return ''.join(open(srcfile).readlines()) + '\n\n'
     except IOError:
-        print 'Could not open', srcfile
+        print('Could not open', srcfile)
         return ''
+
+WRITE_TEMPLATE = """
+if hasattr(sys.stdout, 'buffer'):
+    sys.stdout.buffer.write(powerline.draw())
+else:
+    sys.stdout.write(powerline.draw())
+"""
 
 if __name__ == "__main__":
     source = load_source(TEMPLATE_FILE)
@@ -28,13 +37,13 @@ if __name__ == "__main__":
     source += load_source(os.path.join(THEMES_DIR, config.THEME + '.py'))
     for segment in config.SEGMENTS:
         source += load_source(os.path.join(SEGMENTS_DIR, segment + '.py'))
-    source += 'sys.stdout.write(powerline.draw())\n'
+    source += WRITE_TEMPLATE.strip() + '\n'
 
     try:
         open(OUTPUT_FILE, 'w').write(source)
         st = os.stat(OUTPUT_FILE)
         os.chmod(OUTPUT_FILE, st.st_mode | stat.S_IEXEC)
-        print OUTPUT_FILE, 'saved successfully'
+        print(OUTPUT_FILE, 'saved successfully')
     except IOError:
-        print 'ERROR: Could not write to powerline-shell.py. Make sure it is writable'
+        print('ERROR: Could not write to powerline-shell.py. Make sure it is writable')
         exit(1)

--- a/lib/color_compliment.py
+++ b/lib/color_compliment.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import print_function
 
 from colortrans import *
 from colorsys import hls_to_rgb, rgb_to_hls
@@ -8,8 +9,8 @@ from sys import argv
 
 def getOppositeColor(r,g,b):
     hls = rgb_to_hls(r,g,b)
-    #print "hls is"
-    #print hls
+    #print("hls is")
+    #print(hls)
     opp = list(hls[:])
     #opp[0] = (opp[0]+0.5)%1 # reverse hue (a.k.a. color), reversing tends to be jarring
     opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
@@ -19,7 +20,7 @@ def getOppositeColor(r,g,b):
         opp[1] += 255/2
     if opp[2] > -0.5: # if saturation is low on first color increase second's
         opp[2] -= 0.5
-    #print opp
+    #print(opp)
     opp = hls_to_rgb(*opp)
     m = max(opp)
     if m > 255: #colorsys module doesn't give caps to their conversions

--- a/lib/colortrans.py
+++ b/lib/colortrans.py
@@ -17,6 +17,7 @@ Resources:
 I'm not sure where this script was inspired from. I think I must have
 written it from scratch, though it's been several years now.
 """
+from __future__ import print_function
 
 __author__    = 'Micah Elliott http://MicahElliott.com'
 __version__   = '0.1'
@@ -312,7 +313,7 @@ def rgb2short(r, g, b):
                 res.append(closest)
                 break
             i += 1
-    #print '***', res
+    #print('***', res)
     return RGB2SHORT_DICT[tuple(res)]
 
 #---------------------------------------------------------------------

--- a/powerline-shell.py.template
+++ b/powerline-shell.py.template
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import argparse
 import os
 import sys
 
 def warn(msg):
-    print '[powerline-bash] ', msg
+    print('[powerline-bash] ', msg)
 
 class Powerline:
     symbols = {

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -15,7 +15,10 @@ def get_short_path(cwd):
 
 def add_cwd_segment():
     cwd = powerline.cwd or os.getenv('PWD')
-    names = get_short_path(cwd.decode('utf-8'))
+    try:
+        names = get_short_path(cwd.decode('utf-8'))
+    except AttributeError:
+        names = get_short_path(cwd)
 
     max_depth = powerline.args.cwd_max_depth
     if len(names) > max_depth:

--- a/segments/git.py
+++ b/segments/git.py
@@ -7,7 +7,11 @@ def get_git_status():
     origin_position = ""
     output = subprocess.Popen(['git', 'status', '--ignore-submodules'],
             env={"LANG": "C", "HOME": os.getenv("HOME")}, stdout=subprocess.PIPE).communicate()[0]
-    for line in output.split('\n'):
+    try:
+        lines = output.split('\n')
+    except TypeError:  # Python 3
+        lines = output.decode().split('\n')
+    for line in lines:
         origin_status = re.findall(
             r"Your branch is (ahead|behind).*?(\d+) comm", line)
         if origin_status:
@@ -38,7 +42,11 @@ def add_git_segment():
         branch = '(Detached)'
 
     has_pending_commits, has_untracked_files, origin_position = get_git_status()
-    branch += origin_position
+    try:
+        branch += origin_position
+    except TypeError:
+        branch = branch.decode()
+        branch += origin_position
     if has_untracked_files:
         branch += ' +'
 

--- a/segments/git.py
+++ b/segments/git.py
@@ -29,7 +29,7 @@ def add_git_segment():
     p = subprocess.Popen(['git', 'symbolic-ref', '-q', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
 
-    if 'Not a git repo' in err:
+    if 'Not a git repo' in str(err):
         return
 
     if out:

--- a/segments/hg.py
+++ b/segments/hg.py
@@ -7,7 +7,11 @@ def get_hg_status():
     has_missing_files = False
     output = subprocess.Popen(['hg', 'status'],
             stdout=subprocess.PIPE).communicate()[0]
-    for line in output.split('\n'):
+    try:
+        lines = output.split('\n')
+    except TypeError:  # Python 3
+        lines = output.decode().split('\n')
+    for line in lines:
         if line == '':
             continue
         elif line[0] == '?':

--- a/segments/jobs.py
+++ b/segments/jobs.py
@@ -5,7 +5,7 @@ import subprocess
 def add_jobs_segment():
     pppid = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='], stdout=subprocess.PIPE).communicate()[0].strip()
     output = subprocess.Popen(['ps', '-a', '-o', 'ppid'], stdout=subprocess.PIPE).communicate()[0]
-    num_jobs = len(re.findall(str(pppid), output)) - 1
+    num_jobs = len(re.findall(bytes(pppid), output)) - 1
 
     if num_jobs > 0:
         powerline.append(' %d ' % num_jobs, Color.JOBS_FG, Color.JOBS_BG)

--- a/themes/colortest.py
+++ b/themes/colortest.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import sys
 
 ESCAPE = chr(27)
@@ -14,19 +16,19 @@ def reset():
 
 if __name__ == "__main__":
     if len(sys.argv) < 6:
-        print 'Usage: colortest.py fg_start fg_end bg_start bg_end test_string'
+        print('Usage: colortest.py fg_start fg_end bg_start bg_end test_string')
         sys.exit(1)
 
     fg_start, fg_end, bg_start, bg_end = map(int, sys.argv[1:5])
     test_string = sys.argv[5]
 
-    print ' ' * len(str(bg_start)),
+    print(' ' * len(str(bg_start)), end='')
     for fg_color in range(fg_start, fg_end + 1):
-        print ' ' * (len(test_string) - len(str(fg_color))), fg_color,
-    print
+        print(' ' * (len(test_string) - len(str(fg_color))), fg_color, end='')
+    print()
 
     for bg_color in range(bg_start, bg_end + 1):
-        print bg_color, bg(bg_color),
+        print(bg_color, bg(bg_color), end='')
         for fg_color in range(fg_start, fg_end + 1):
-            print fg(fg_color), test_string,
-        print reset()
+            print(fg(fg_color), test_string, end='')
+        print(reset())


### PR DESCRIPTION
I've been happily using powerline-shell on OSX for quite some time now. Thanks for building it.

I created a Python 3.4 virtualenv using Python3's builtin pyvenv command and powerline-shell would break anytime I activate it, powerline-shell would barf out. I decided to spend some time making things cross compatible between python2 (>= 2.6) and python3. It turned out to be far easier than I'd anticipated it to be.

I've been using this patched version for the past couple of days with Python 2.7 and Python 3.4.  I found that this issue had been reported earlier on #118, but I couldn't find a way to attach a pull request against that issue. I've also got another branch with a few pep8 fixes on top of this, but that should probably be addressed separately.