### PR TITLE
Fix zsh root_indicator

### DIFF
--- a/segments/root.py
+++ b/segments/root.py
@@ -1,7 +1,7 @@
 def add_root_indicator_segment():
     root_indicators = {
         'bash': ' \\$ ',
-        'zsh': ' \\$ ',
+        'zsh': ' %# ',
         'bare': ' $ ',
     }
     bg = Color.CMD_PASSED_BG


### PR DESCRIPTION
The original root_indicator for zsh will always show as '\$' for root or non-root users. Fixed as below. The expected results are:
1. showing '%' for non-root users.
2. showing '#' for root. The easiest way to test is 'su -p'.
