### PR TITLE
Add an optional 'plain' mode to the cwd segment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ setting your $TERM to `xterm-256color`, because that works for me.
 There are a few optional arguments which can be seen by running `powerline-shell.py --help`.
 
 ```
-  --cwd-only            Only show the current directory
+  --cwd-mode {fancy,plain,dironly}
+                        How to display the current directory
   --cwd-max-depth CWD_MAX_DEPTH
                         Maximum number of directories to show in path
   --colorize-hostname   Colorize the hostname based on a hash of itself.

--- a/powerline-shell.py.template
+++ b/powerline-shell.py.template
@@ -104,8 +104,11 @@ def get_valid_cwd():
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--cwd-mode', action='store',
+            help='How to display the current directory', default='fancy',
+            choices=['fancy', 'plain', 'dironly'])
     arg_parser.add_argument('--cwd-only', action='store_true',
-            help='Only show the current directory')
+            help='Deprecated. Use --cwd-mode=dironly')
     arg_parser.add_argument('--cwd-max-depth', action='store', type=int,
             default=5, help='Maximum number of directories to show in path')
     arg_parser.add_argument('--colorize-hostname', action='store_true',

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -22,7 +22,8 @@ def add_cwd_segment():
         names = names[:2] + [u'\u2026'] + names[2 - max_depth:]
 
     if powerline.args.cwd_mode=='plain':
-        powerline.append(' %s ' % '/'.join(names), Color.CWD_FG, Color.PATH_BG)
+        powerline.append(' %s%s ' % ('' if names[0] in '/~' else '/', '/'.join(names)), 
+            Color.CWD_FG, Color.PATH_BG)
     else:
         if not (powerline.args.cwd_mode=='dironly' or powerline.args.cwd_only):
             for n in names[:-1]:

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -22,8 +22,7 @@ def add_cwd_segment():
         names = names[:2] + [u'\u2026'] + names[2 - max_depth:]
 
     if powerline.args.cwd_mode=='plain':
-        powerline.append(' %s%s ' % ('' if names[0] in '/~' else '/', '/'.join(names)), 
-            Color.CWD_FG, Color.PATH_BG)
+        powerline.append(cwd, Color.CWD_FG, Color.PATH_BG)
     else:
         if not (powerline.args.cwd_mode=='dironly' or powerline.args.cwd_only):
             for n in names[:-1]:

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -21,17 +21,20 @@ def add_cwd_segment():
     if len(names) > max_depth:
         names = names[:2] + [u'\u2026'] + names[2 - max_depth:]
 
-    if not powerline.args.cwd_only:
-        for n in names[:-1]:
-            if n == '~' and Color.HOME_SPECIAL_DISPLAY:
-                powerline.append(' %s ' % n, Color.HOME_FG, Color.HOME_BG)
-            else:
-                powerline.append(' %s ' % n, Color.PATH_FG, Color.PATH_BG,
-                    powerline.separator_thin, Color.SEPARATOR_FG)
-
-    if names[-1] == '~' and Color.HOME_SPECIAL_DISPLAY:
-        powerline.append(' %s ' % names[-1], Color.HOME_FG, Color.HOME_BG)
+    if powerline.args.cwd_mode=='plain':
+        powerline.append(' %s ' % '/'.join(names), Color.CWD_FG, Color.PATH_BG)
     else:
-        powerline.append(' %s ' % names[-1], Color.CWD_FG, Color.PATH_BG)
+        if not (powerline.args.cwd_mode=='dironly' or powerline.args.cwd_only):
+            for n in names[:-1]:
+                if n == '~' and Color.HOME_SPECIAL_DISPLAY:
+                    powerline.append(' %s ' % n, Color.HOME_FG, Color.HOME_BG)
+                else:
+                    powerline.append(' %s ' % n, Color.PATH_FG, Color.PATH_BG,
+                        powerline.separator_thin, Color.SEPARATOR_FG)
+
+        if names[-1] == '~' and Color.HOME_SPECIAL_DISPLAY:
+            powerline.append(' %s ' % names[-1], Color.HOME_FG, Color.HOME_BG)
+        else:
+            powerline.append(' %s ' % names[-1], Color.CWD_FG, Color.PATH_BG)
 
 add_cwd_segment()


### PR DESCRIPTION
Rationale: A plain path like "~/projects/powerline-shell" can be easily copied&pasted, and also takes up less space in the prompt.

The new command line parameter --cwd-mode controls the display of the cwd segment:
--cwd-mode=fancy is the same as the current default
--cwd-mode=plain is the new mode to display a plain path
--cwd-mode=dironly is the same as the old parameter --cwd-only (which is still supported to keep backward compat)