### PR TITLE
Fix bugs with bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There are a few optional arguments which can be seen by running `powerline-shell
 Add the following to your `~/.bashrc`:
 
         function _update_ps1() {
-           export PS1="$(photon ~/powerline-shell.py $? 2> /dev/null)"
+           export PS1="$(python ~/powerline-shell.py $? 2> /dev/null)"
         }
 
         export PROMPT_COMMAND="_update_ps1;$PROMPT_COMMAND"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are a few optional arguments which can be seen by running `powerline-shell
 ```
 
 ### Bash:
-Add the following to your `~/.bashrc`:
+Add the following to your `.bashrc`:
 
         function _update_ps1() {
            export PS1="$(python ~/powerline-shell.py $? 2> /dev/null)"
@@ -63,7 +63,7 @@ Add the following to your `~/.bashrc`:
 
         export PROMPT_COMMAND="_update_ps1;$PROMPT_COMMAND"
 
-**Note:** If you use OS X 10.9+ and don't exist `~/.bashrc` file or `~/.profile` file, run `touch ~/.profile` and add the above code. 
+**Note:** If you prefer, you can use `~/.profile` file, exec `touch ~/.profile` and add the above code. 
 
 
 ### ZSH:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ setting your $TERM to `xterm-256color`, because that works for me.
 
   * This will generate `powerline-shell.py`
 
-* (optional) Create a symlink to this python script in your home:
-
-        ln -s <path/to/powerline-shell.py> ~/powerline-shell.py
-
-  * If you don't want the symlink, just modify the path in the commands below
+* If you don't install python, it's the moment.
 
 * For python2.6 you have to install argparse
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,16 @@ There are a few optional arguments which can be seen by running `powerline-shell
 ```
 
 ### Bash:
-Add the following to your `.bashrc`:
+Add the following to your `~/.bashrc`:
 
         function _update_ps1() {
-           export PS1="$(~/powerline-shell.py $? 2> /dev/null)"
+           export PS1="$(photon ~/powerline-shell.py $? 2> /dev/null)"
         }
 
-        export PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
+        export PROMPT_COMMAND="_update_ps1;$PROMPT_COMMAND"
+
+**Note:** If you use OS X 10.9+ and don't exist `~/.bashrc` file or `~/.profile` file, run `touch ~/.profile` and add the above code. 
+
 
 ### ZSH:
 Add the following to your `.zshrc`:
@@ -90,7 +93,7 @@ Redefine `fish_prompt` in ~/.config/fish/config.fish:
 
         function fish_prompt
             ~/powerline-shell.py $status --shell bare ^/dev/null
-        end
+        end                
 
 # Customization
 


### PR DESCRIPTION
* It's necessary use `python powerline-shell.py` to run script.
* Symbolic link don't works.
* Add advice install python.