### PR TITLE
Added option to allow for use in a bash echo

### DIFF
--- a/powerline-shell.py.template
+++ b/powerline-shell.py.template
@@ -31,7 +31,8 @@ class Powerline:
     }
 
     color_templates = {
-        'bash': '\\[\\e%s\\]',
+        'bash-line': '\\[\\e%s\\]',
+        'bash': '\\033%s',
         'zsh': '%%{%s%%}',
         'bare': '%s',
     }
@@ -118,7 +119,7 @@ if __name__ == "__main__":
             help='The characters used to make separators between segments',
             choices=['patched', 'compatible', 'flat'])
     arg_parser.add_argument('--shell', action='store', default='bash',
-            help='Set this to your shell type', choices=['bash', 'zsh', 'bare'])
+            help='Set this to your shell type', choices=['bash-line', 'bash', 'zsh', 'bare'])
     arg_parser.add_argument('prev_error', nargs='?', type=int, default=0,
             help='Error code returned by the last command')
     args = arg_parser.parse_args()

--- a/segments/hostname.py
+++ b/segments/hostname.py
@@ -10,7 +10,7 @@ def add_hostname_segment():
 
         powerline.append(host_prompt, FG, BG)
     else:
-        if powerline.args.shell == 'bash':
+        if powerline.args.shell == 'bash-line':
             host_prompt = ' \\h '
         elif powerline.args.shell == 'zsh':
             host_prompt = ' %m '

--- a/segments/root.py
+++ b/segments/root.py
@@ -1,6 +1,7 @@
 def add_root_indicator_segment():
     root_indicators = {
-        'bash': ' \\$ ',
+        'bash-line': ' \\$ ',
+        'bash': '',
         'zsh': ' \\$ ',
         'bare': ' $ ',
     }

--- a/segments/username.py
+++ b/segments/username.py
@@ -1,7 +1,7 @@
 
 def add_username_segment():
     import os
-    if powerline.args.shell == 'bash':
+    if powerline.args.shell == 'bash-line':
         user_prompt = ' \\u '
     elif powerline.args.shell == 'zsh':
         user_prompt = ' %n '


### PR DESCRIPTION
FEATURE ADD
---------------------
The `bash` option is for a user who want to echo out in  any `echo -e "$(python powerline-shell.py --shell bash)"` statement
The `bash-line` option if for a user who wants to include this on their $PS1 line.