### PR TITLE
Add rc segment to display the actual return code of the last command

### DIFF
--- a/config.py.dist
+++ b/config.py.dist
@@ -45,6 +45,10 @@ SEGMENTS = [
 # Show number of running jobs
     'jobs',
 
+# Shows a non-zero return code of the last command
+# Only visible when the command failed
+    'rc',
+
 # Shows a '#' if the current user is root, '$' otherwise
 # Also, changes color if the last command exited with a non-zero error code
     'root',

--- a/segments/rc.py
+++ b/segments/rc.py
@@ -1,0 +1,8 @@
+def add_rc_indicator_segment():
+    if powerline.args.prev_error != 0:
+        fg = Color.CMD_FAILED_FG
+        bg = Color.CMD_FAILED_BG
+        text = '%d' % (powerline.args.prev_error)
+        powerline.append(text, fg, bg)
+
+add_rc_indicator_segment()


### PR DESCRIPTION
This works as addition to the root segment.
![screenshot from 2015-02-12 14 31 51](https://cloud.githubusercontent.com/assets/121874/6168275/1535e6d0-b2c4-11e4-8b64-abee8b60a17a.png)
