### PR TITLE
Fix powerline-shell to work along with a Python 3 virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ There are a few optional arguments which can be seen by running `powerline-shell
                         segments
 ```
 
+HINT: In order to use powerline-shell along with a Python 3 virtualenv, the following snippet should be put into your .bashrc, .bash_profile, .zshrc and so on:
+
+        alias python2='python'
+
 ### Bash:
 Add the following to your `.bashrc`:
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ There are a few optional arguments which can be seen by running `powerline-shell
 HINT: In order to use powerline-shell along with a Python 3 virtualenv, the following snippet should be put into your .bashrc, .bash_profile, .zshrc and so on:
 
         alias python2='python'
+        
+and then change your powerline-shell.py to use python2 instead.
 
 ### Bash:
 Add the following to your `.bashrc`:


### PR DESCRIPTION
This is a little workaround to make it possible to use the amazing powerline-shell along with a Python 3 virtualenv.