### PR TITLE
Allow virtualenv segment to be from Anaconda

### DIFF
--- a/segments/virtual_env.py
+++ b/segments/virtual_env.py
@@ -1,7 +1,7 @@
 import os
 
 def add_virtual_env_segment():
-    env = os.getenv('VIRTUAL_ENV')
+    env = os.getenv('VIRTUAL_ENV') or os.getenv('CONDA_ENV_PATH')
     if env is None:
         return
 


### PR DESCRIPTION
PR enables virtualenv segment label to pull name from environments created with [Anaconda](http://conda.pydata.org/docs/intro.html), not just `virtualenv`. The two are mutually exclusive in their uses but `virtualenv` should override in the unusual circumstance of them coexisting.

Thanks for maintaining this great package!