### PR TITLE
Adjusted behaviour of --cwd-max-depth to avoid repetitions.

### DIFF
--- a/powerline_shell_base.py
+++ b/powerline_shell_base.py
@@ -82,6 +82,13 @@ class Powerline:
             self.fgcolor(segment[4]),
             segment[3]))
 
+def find_project_root(dirname):
+    d = os.path.abspath(os.path.curdir)
+    while len(d) > 1:
+        d, base = os.path.split(d)
+        if os.path.isdir(os.path.join(d,base, ".git")):
+            return os.path.join(d,base)
+
 def get_valid_cwd():
     """ We check if the current working directory is valid or not. Typically
         happens when you checkout a different branch on git that doesn't have

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -49,8 +49,8 @@ def add_cwd_segment():
     names = split_path_into_names(cwd)
 
     max_depth = powerline.args.cwd_max_depth
-    if len(names) > max_depth:
-        names = names[:2] + [u'\u2026'] + names[2 - max_depth:]
+    if len(names) > int(max_depth) + 3:
+        names = names[:2] + [u'\u2026'] + names[len(names) - max_depth:]
 
     if powerline.args.cwd_mode == 'plain':
         powerline.append(' %s ' % (cwd,), Color.CWD_FG, Color.PATH_BG)

--- a/segments/git.py
+++ b/segments/git.py
@@ -28,6 +28,8 @@ def get_git_status():
 
 
 def add_git_segment():
+    if not find_project_root(".git"):
+        return False
     # See http://git-blame.blogspot.com/2013/06/checking-current-branch-programatically.html
     p = subprocess.Popen(['git', 'symbolic-ref', '-q', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()

--- a/segments/hg.py
+++ b/segments/hg.py
@@ -19,6 +19,8 @@ def get_hg_status():
     return has_modified_files, has_untracked_files, has_missing_files
 
 def add_hg_segment():
+    if not find_project_root(".hg"):
+        return False
     branch = os.popen('hg branch 2> /dev/null').read().rstrip()
     if len(branch) == 0:
         return False


### PR DESCRIPTION
Hi, 
I'm using 

    powerline-shell.py --cwd-max-depth 2 $?

And was getting 

    cd a/huge/load/of/directories/that/one/would/not/like/to/see/
    ~ a …  ~ a  huge  load  of  directories  that  one would  not  like  to  see $

After the fix it is:

    ~ a … to see $


