### PR TITLE
git segment: don't show repo as dirty when only untracked files

### DIFF
--- a/segments/git.py
+++ b/segments/git.py
@@ -20,7 +20,7 @@ def get_git_status():
         if diverged_status:
             origin_position = " %d%c %d%c" % (int(diverged_status[0][0]), u'\u21E1', int(diverged_status[0][1]), u'\u21E3')
 
-        if line.find('nothing to commit') >= 0:
+        if line.find('nothing to commit') >= 0 or line.find('nothing added to commit but untracked files present') >= 0:
             has_pending_commits = False
         if line.find('Untracked files') >= 0:
             has_untracked_files = True


### PR DESCRIPTION
The ``+`` used to denote untracked files should be independent of the background colour showing the repo as clean or dirty. The way it is currently, it's hard to tell at a glance whether a tracked file has been modified, or there's only untracked files present.

Screenshot below is my solution:
![just_untracked_not_dirty](https://cloud.githubusercontent.com/assets/3755307/10935730/ea58aa14-82df-11e5-9f99-4f3fcb1c4781.png)
