### PR TITLE
Add padding to exit_code segment

### DIFF
--- a/segments/exit_code.py
+++ b/segments/exit_code.py
@@ -3,6 +3,6 @@ def add_exit_code_segment():
         return
     fg = Color.CMD_FAILED_FG
     bg = Color.CMD_FAILED_BG
-    powerline.append(str(powerline.args.prev_error), fg, bg)
+    powerline.append(' %s ' % str(powerline.args.prev_error), fg, bg)
 
 add_exit_code_segment()


### PR DESCRIPTION
The 2nd prompt is how the exit_code segment looks now and the last example is with this extra padding.

![screen shot 2015-11-16 at 9 26 58 pm](https://cloud.githubusercontent.com/assets/28851/11202943/4743b726-8cab-11e5-82f9-2531a960c17a.png)
