### PR TITLE
fix python3 compatibility

### DIFF
--- a/powerline_shell_base.py
+++ b/powerline_shell_base.py
@@ -6,8 +6,12 @@ import argparse
 import os
 import sys
 
+py3 = sys.version_info.major == 3
+
+
 def warn(msg):
     print('[powerline-bash] ', msg)
+
 
 class Powerline:
     symbols = {
@@ -67,8 +71,12 @@ class Powerline:
             separator_fg if separator_fg is not None else bg))
 
     def draw(self):
-        return (''.join(self.draw_segment(i) for i in range(len(self.segments)))
-                + self.reset).encode('utf-8') + ' '
+        text = (''.join(self.draw_segment(i) for i in range(len(self.segments)))
+                + self.reset) + ' '
+        if py3:
+            return text
+        else:
+            return text.encode('utf-8')
 
     def draw_segment(self, idx):
         segment = self.segments[idx]

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -47,6 +47,8 @@ def get_fg_bg(name):
 
 def add_cwd_segment():
     cwd = powerline.cwd or os.getenv('PWD')
+    if not py3:
+        cwd = cwd.decode("utf-8")
     cwd = replace_home_dir(cwd)
 
     if powerline.args.cwd_mode == 'plain':

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -46,7 +46,7 @@ def get_fg_bg(name):
 
 
 def add_cwd_segment():
-    cwd = (powerline.cwd or os.getenv('PWD')).decode('utf-8')
+    cwd = powerline.cwd or os.getenv('PWD')
     cwd = replace_home_dir(cwd)
 
     if powerline.args.cwd_mode == 'plain':

--- a/segments/git.py
+++ b/segments/git.py
@@ -33,10 +33,9 @@ def _get_git_detached_branch():
     p = subprocess.Popen(['git', 'describe', '--tags', '--always'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                          env=git_subprocess_env)
-    detached_ref = p.communicate()[0].rstrip('\n')
+    detached_ref = p.communicate()[0].decode("utf-8").rstrip('\n')
     if p.returncode == 0:
-        branch = u'{} {}'.format(GIT_SYMBOLS['detached'],
-                                 detached_ref.decode('utf-8'))
+        branch = u'{} {}'.format(GIT_SYMBOLS['detached'], detached_ref)
     else:
         branch = 'Big Bang'
     return branch
@@ -71,7 +70,7 @@ def add_git_segment():
     if p.returncode != 0:
         return
 
-    status = pdata[0].splitlines()
+    status = pdata[0].decode("utf-8").splitlines()
 
     branch_info = parse_git_branch_info(status)
     stats = parse_git_stats(status)

--- a/segments/hg.py
+++ b/segments/hg.py
@@ -5,8 +5,10 @@ def get_hg_status():
     has_modified_files = False
     has_untracked_files = False
     has_missing_files = False
-    output = subprocess.Popen(['hg', 'status'],
-            stdout=subprocess.PIPE).communicate()[0]
+
+    p = subprocess.Popen(['hg', 'status'], stdout=subprocess.PIPE)
+    output = p.communicate()[0].decode("utf-8")
+
     for line in output.split('\n'):
         if line == '':
             continue

--- a/segments/jobs.py
+++ b/segments/jobs.py
@@ -3,8 +3,14 @@ import re
 import subprocess
 
 def add_jobs_segment():
-    pppid = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='], stdout=subprocess.PIPE).communicate()[0].strip()
-    output = subprocess.Popen(['ps', '-a', '-o', 'ppid'], stdout=subprocess.PIPE).communicate()[0]
+    pppid_proc = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='],
+                                  stdout=subprocess.PIPE)
+    pppid = pppid_proc.communicate()[0].decode("utf-8").strip()
+
+    output_proc = subprocess.Popen(['ps', '-a', '-o', 'ppid'],
+                                   stdout=subprocess.PIPE)
+    output = output_proc.communicate()[0].decode("utf-8")
+
     num_jobs = len(re.findall(str(pppid), output)) - 1
 
     if num_jobs > 0:

--- a/segments/node_version.py
+++ b/segments/node_version.py
@@ -4,7 +4,7 @@ import subprocess
 def add_node_version_segment():
     try:
         p1 = subprocess.Popen(["node", "--version"], stdout=subprocess.PIPE)
-        version = p1.communicate()[0].rstrip()
+        version = p1.communicate()[0].decode("utf-8").rstrip()
         version = "node " + version
         powerline.append(version, 15, 18)
     except OSError:

--- a/segments/ruby_version.py
+++ b/segments/ruby_version.py
@@ -5,7 +5,7 @@ def add_ruby_version_segment():
     try:
         p1 = subprocess.Popen(["ruby", "-v"], stdout=subprocess.PIPE)
         p2 = subprocess.Popen(["sed", "s/ (.*//"], stdin=p1.stdout, stdout=subprocess.PIPE)
-        version = p2.communicate()[0].rstrip()
+        version = p2.communicate()[0].decode("utf-8").rstrip()
         if os.environ.has_key("GEM_HOME"):
           gem = os.environ["GEM_HOME"].split("@")
           if len(gem) > 1:

--- a/segments/svn.py
+++ b/segments/svn.py
@@ -1,8 +1,9 @@
 import subprocess
 
 def add_svn_segment():
-    is_svn = subprocess.Popen(['svn', 'status'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    is_svn_output = is_svn.communicate()[1].strip()
+    is_svn = subprocess.Popen(['svn', 'status'],
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    is_svn_output = is_svn.communicate()[1].decode("utf-8").strip()
     if len(is_svn_output) != 0:
         return
 
@@ -11,7 +12,7 @@ def add_svn_segment():
             stderr=subprocess.PIPE)
     p2 = subprocess.Popen(['grep', '-c', '^[ACDIMR\\!\\~]'],
             stdin=p1.stdout, stdout=subprocess.PIPE)
-    output = p2.communicate()[0].strip()
+    output = p2.communicate()[0].decode("utf-8").strip()
     if len(output) > 0 and int(output) > 0:
         changes = output.strip()
         powerline.append(' %s ' % changes, Color.SVN_CHANGES_FG, Color.SVN_CHANGES_BG)


### PR DESCRIPTION
closes #66, #118, #137, #140, #192, #206 

^ This seems to be the most pressing issue to resolve. I'm hoping to fix python3 compatibility once and for all in this branch. Looking for feedback from anyone who knows more about this stuff.

Notes on the changes in here:

* os.getenv and related functions return strings, not unicode (in python 2). This will cause an issue in the `draw` function if you do not decode the string into utf-8 and there are non-ascii characters in the string, because concatenating a unicode object and a string causes Python to try to implicitly convert the ASCII to unicode, but can't convert the non-ascii character. Here is some that demos this:

```python
>>> x = "powerline-shell-\xe2\x9c\x8e" # bytes to make the pencil utf-8 character
>>> x + u""
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 16: ordinal not in range(128)
```

* In Python 3, everything is unicode. There is also no `str.decode` function.
* However, in Python 3, the `subprocess` functions return `bytes` instead of `unicode`. Thus we must always decode the bytes into unicode. This works just fine though since in Python 2, `subprocess` returns strings which must also be decoded into unicode.

Tests:

- [x] `cd` into directory with non-ascii character in its name (py2)
- [x] `cd` into directory with non-ascii character in its name (py3)
- [x] git branch has unicode char (py2)
- [x] git branch has unicode char (py3)
- [x] hg basic test (py2)
- [x] hg basic test (py3)
- [x] basic jobs test
- [x] basic ruby/node version tests