### PR TITLE
Py3 fixes to lib/color_compliment.py

### DIFF
--- a/lib/color_compliment.py
+++ b/lib/color_compliment.py
@@ -2,7 +2,11 @@
 
 from colortrans import *
 from colorsys import hls_to_rgb, rgb_to_hls
-from md5 import md5
+# md5 deprecated since Python 2.5
+try:
+    from md5 import md5
+except ImportError:
+    from hashlib import md5
 from sys import argv
 
 

--- a/lib/color_compliment.py
+++ b/lib/color_compliment.py
@@ -1,6 +1,4 @@
 #! /usr/bin/env python
-
-from colortrans import *
 from colorsys import hls_to_rgb, rgb_to_hls
 # md5 deprecated since Python 2.5
 try:
@@ -8,6 +6,9 @@ try:
 except ImportError:
     from hashlib import md5
 from sys import argv
+
+# Original, non-relative import errors on Python3
+from .colortrans import *
 
 
 def getOppositeColor(r,g,b):

--- a/lib/color_compliment.py
+++ b/lib/color_compliment.py
@@ -10,7 +10,7 @@ import sys
 # Original, non-relative import errors on Python3
 from .colortrans import *
 
-py3 = sys.version_info.major == 3
+py3 = sys.version_info[0] == 3
 
 
 def getOppositeColor(r,g,b):

--- a/lib/color_compliment.py
+++ b/lib/color_compliment.py
@@ -5,10 +5,12 @@ try:
     from md5 import md5
 except ImportError:
     from hashlib import md5
-from sys import argv
+import sys
 
 # Original, non-relative import errors on Python3
 from .colortrans import *
+
+py3 = sys.version_info.major == 3
 
 
 def getOppositeColor(r,g,b):
@@ -32,6 +34,10 @@ def getOppositeColor(r,g,b):
     return tuple([ int(x) for x in opp])
 
 def stringToHashToColorAndOpposite(string):
+    # Python3: Unicode string must be encoded before digest
+    # Python2.7: works either way, but check in case breaks earlier py2
+    if py3:
+        string = string.encode('utf-8')
     string = md5(string).hexdigest()[:6] # get a random color
     color1 = rgbstring2tuple(string)
     color2 = getOppositeColor(*color1)


### PR DESCRIPTION
PR fixes three bugs identified when using `--colorized-hostname` with Python3. I don't have confirmation yet, but this likely addresses issue #216. I used `try/except` blocks and version checks to be conservative and ensure this doesn't break for anyone on a very old Python 2 version, but this was probably excessive and isn't something I would have done on my own project. I'd be happy to remove them if there are concerns about the overhead. 

With these changes made, I've had no problems on Python 2.6.6, 2.7.10, and 3.5.1.


Issue 1 fixed in ceholden/powerline-shell@1f1acb81cba48e35820c4a88b4c39ab5ff40db42:
``` python
Traceback (most recent call last):
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 272, in <module>
    add_hostname_segment()
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 251, in add_hostname_segment
    from lib.color_compliment import stringToHashToColorAndOpposite
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/lib/color_compliment.py", line 3, in <module>
    from colortrans import *
ImportError: No module named 'colortrans'
```

Issue 2 fixed in ceholden/powerline-shell@c07c4be6b4e410a56bc95284bb553f5b1baaa7f7:
``` python
$HOME/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py --cwd-only --colorize-hostname
Traceback (most recent call last):
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 272, in <module>
    add_hostname_segment()
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 255, in add_hostname_segment
    FG, BG = stringToHashToColorAndOpposite(hostname)
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/lib/color_compliment.py", line 35, in stringToHashToColorAndOpposite
    string = md5(string).hexdigest()[:6] # get a random color
TypeError: Unicode-objects must be encoded before hashing
```

Issue 3, previously mentioned but not merged in #82, fixed in ceholden/powerline-shell@6bef8fab1dc86739f6073d8dfbacc1fb20dc1edc:
``` python
Traceback (most recent call last):
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 272, in <module>
    add_hostname_segment()
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/powerline-shell.py", line 251, in add_hostname_segment
    from lib.color_compliment import stringToHashToColorAndOpposite
  File "/home/ceholden/.homesick/repos/dotfiles/powerline-shell/lib/color_compliment.py", line 5, in <module>
    from md5 import md5
ImportError: No module named 'md5
```
